### PR TITLE
feat(*): Added icon changing for waystones

### DIFF
--- a/src/main/java/dev/pozzoo/quickwaystones/data/WaystoneData.java
+++ b/src/main/java/dev/pozzoo/quickwaystones/data/WaystoneData.java
@@ -2,6 +2,7 @@ package dev.pozzoo.quickwaystones.data;
 
 import dev.pozzoo.quickwaystones.QuickWaystones;
 import org.bukkit.Location;
+import org.bukkit.Material;
 
 import java.util.UUID;
 
@@ -11,6 +12,7 @@ public class WaystoneData {
     private final UUID owner;
     private final Location location;
     private int direction = 0;
+    private Material icon = Material.ENDER_PEARL;
 
     public WaystoneData(Location location, UUID owner) {
         id = QuickWaystones.getAndIncrementLastWaystoneID();
@@ -18,12 +20,13 @@ public class WaystoneData {
         this.location = location;
         this.owner = owner;
     }
-    public WaystoneData(Integer id, String name, Location location, UUID owner, int direction) {
+    public WaystoneData(Integer id, String name, Location location, UUID owner, int direction, Material icon) {
         this.id = id;
         this.name = name;
         this.location = location;
         this.owner = owner;
         this.direction = direction;
+        this.icon = icon;
     }
 
     public int getId() {
@@ -52,6 +55,14 @@ public class WaystoneData {
 
     public void setDirection(int direction) {
         this.direction = direction;
+    }
+
+    public Material getIcon() {
+        return icon;
+    }
+
+    public void setIcon(Material icon) {
+        this.icon = icon;
     }
 
     @Override

--- a/src/main/java/dev/pozzoo/quickwaystones/gui/WaystoneGUI.java
+++ b/src/main/java/dev/pozzoo/quickwaystones/gui/WaystoneGUI.java
@@ -9,6 +9,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
@@ -71,7 +72,7 @@ public class WaystoneGUI implements Listener {
         int slot = 0;
         for (int i = startIndex; i < endIndex; i++) {
             WaystoneData ws = waystones.get(i);
-            ItemStack item = new ItemStack(Material.ENDER_PEARL);
+            ItemStack item = new ItemStack(ws.getIcon());
             ItemMeta meta = item.getItemMeta();
             if (meta != null) {
                 meta.displayName(StringUtils.formatItemName(ws.getName()));
@@ -133,7 +134,6 @@ public class WaystoneGUI implements Listener {
         if (!(event.getInventory().getHolder() instanceof WaystoneHolder holder)) {
             return;
         }
-        event.setCancelled(true);
 
         if (!(event.getWhoClicked() instanceof Player player)) {
             return;
@@ -142,8 +142,12 @@ public class WaystoneGUI implements Listener {
         int slot = event.getRawSlot();
         // Only handle clicks inside the top inventory
         if (slot < 0 || slot >= INVENTORY_SIZE) {
+            if (event.isShiftClick()) {
+                event.setCancelled(true);
+            }
             return;
         }
+        event.setCancelled(true);
 
         // Pagination
         if (slot == PREV_SLOT && holder.page > 0) {
@@ -158,6 +162,17 @@ public class WaystoneGUI implements Listener {
         // Waystone teleport
         WaystoneData ws = holder.slotToWaystone.get(slot);
         if (ws != null) {
+            ItemStack cursor = event.getCursor();
+            if (cursor != null && cursor.getType() != Material.AIR) {
+                ws.setIcon(cursor.getType());
+                QuickWaystones.saveData();
+                String message = QuickWaystones.getInstance().getConfig().getString("Messages.WaystoneIconChanged", "Waystone icon changed!");
+                player.sendMessage(StringUtils.formatString("<green>" + message));
+                player.playSound(player, Sound.BLOCK_NOTE_BLOCK_PLING, 0.5f, 1.5f);
+                openPage(player, holder.page, holder.waystoneData);
+                return;
+            }
+
             if (ws.getId() == holder.waystoneData.getId()) {
                 String message = QuickWaystones.getInstance().getConfig().getString("Messages.SameWaystone", "You cannot teleport to the same waystone!");
                 player.sendMessage(StringUtils.formatString("<red>" + message));
@@ -186,6 +201,17 @@ public class WaystoneGUI implements Listener {
             player.getWorld().spawnParticle(Particle.PORTAL, player.getLocation(), 5);
             player.playSound(player, Sound.ENTITY_FOX_TELEPORT, 0.5f, 1f);
             player.closeInventory();
+        }
+    }
+
+    @EventHandler
+    public void onInventoryDrag(InventoryDragEvent event) {
+        if (!(event.getInventory().getHolder() instanceof WaystoneHolder)) {
+            return;
+        }
+        boolean affectsGui = event.getRawSlots().stream().anyMatch(slot -> slot < INVENTORY_SIZE);
+        if (affectsGui) {
+            event.setCancelled(true);
         }
     }
 }

--- a/src/main/java/dev/pozzoo/quickwaystones/managers/DataManager.java
+++ b/src/main/java/dev/pozzoo/quickwaystones/managers/DataManager.java
@@ -3,6 +3,7 @@ package dev.pozzoo.quickwaystones.managers;
 import dev.pozzoo.quickwaystones.QuickWaystones;
 import dev.pozzoo.quickwaystones.data.WaystoneData;
 import java.io.File;
+import org.bukkit.Material;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -81,12 +82,20 @@ public class DataManager {
                 }
 
                 int id = Integer.parseInt(key);
+                String iconName = config.getString(basePath + ".icon", "ENDER_PEARL");
+                Material icon;
+                try {
+                    icon = Material.valueOf(iconName);
+                } catch (IllegalArgumentException e) {
+                    icon = Material.ENDER_PEARL;
+                }
                 WaystoneData waystoneData = new WaystoneData(
                     id,
                     config.getString(basePath + ".name", "Waystone " + id),
                     location,
                     UUID.fromString(ownerValue),
-                    config.getInt(basePath + ".direction", 0)
+                    config.getInt(basePath + ".direction", 0),
+                    icon
                 );
                 QuickWaystones.getWaystonesMap().put(
                     waystoneData.getLocation(),
@@ -142,6 +151,7 @@ public class DataManager {
             config.set(basePath + ".location", waystone.getLocation());
             config.set(basePath + ".owner", waystone.getOwner().toString());
             config.set(basePath + ".direction", waystone.getDirection());
+            config.set(basePath + ".icon", waystone.getIcon().name());
         }
 
         playerAccess

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -14,3 +14,4 @@ Messages:
   SetWaystoneSouth: "Set To Spawn South"
   SetWaystoneEast: "Set To Spawn East"
   SetWaystoneWest: "Set To Spawn West"
+  WaystoneIconChanged: "Waystone icon changed!"


### PR DESCRIPTION
- Added the ability to change a waystones icon by clicking it in the GUI while holding an item on the cursor
- Plays a sound and sends a chat confirmation message when the icon is changed
- Enabled player inventory clicks in the GUI, which initially allowed shift clicking and dragging items in. Both are now prevented